### PR TITLE
wraps csv values with commas with quote marks

### DIFF
--- a/meteor/lib/helpers.js
+++ b/meteor/lib/helpers.js
@@ -120,7 +120,12 @@ jsonToCSV = function(objArray, config) {
 
     for (var j = 0; j < array[i].length; j++) {
       if (line != '') { line += opt.delimiter };
-      line += array[i][j];
+      if (array[i][j].match(/,/)) {
+        line += '\"' + array[i][j] + '\"';
+      } else {
+        line += array[i][j];
+      }
+
     }
 
     if (i === array.length - 1) {


### PR DESCRIPTION
See #41. Checks for commas and if it encounters them in a string, wraps the CSV in escaped quote marks. Should address issues where you want to represent data that has commas in the keys, like so:

```
Type,Percentage
"Larceny, forgery, cybercrime, ID theft",35
Drugs or narcotics,25
"Assault, robbery or burglary",15
Homicide or attempted murder,8
Sex crimes,8
Weapons charge,6
Other,3
```