### PR TITLE
Removes limit from tagging and fixes broken tagging

### DIFF
--- a/meteor/client/templates/chart-edit/chart-edit-tags.js
+++ b/meteor/client/templates/chart-edit/chart-edit-tags.js
@@ -2,24 +2,30 @@ Template.chartEditTags.rendered = function() {
 
   var chartId = Session.get("chartId");
 
-  var tagsSelect = $('#tags-select').reactiveSelectize({
+  var tagsSelect = new ReactiveSelectizeController({
       maxItems: null,
       createOnBlur: true,
       valueField: '_id',
       labelField: 'tagName',
-      searchField: 'tagName',
+      searchField: ['tagName'],
       options: function() { return Tags.find(); },
       create: function(input, callback) {
         var tagName = input;
         var self = this;
-        Meteor.call('createTag', input, chartId, function(err, result) {
-          if (err) {
-            console.log(err);
-          } else if (result) {
-            Meteor.call('updateTags', chartId, tagName);
-            callback(result);
-          }
-        });
+        var availableTags = chartTags(chartId).fetch();
+        if (availableTags.map(function(p) { return p.tagName; }).indexOf(tagName) === -1) {
+          Meteor.call('createTag', input, chartId, function(err, result) {
+            if (err) {
+              console.log(err);
+            } else if (result) {
+              debugger;
+              Meteor.call('updateTags', chartId, tagName);
+              callback(result);
+            }
+          });
+        } else {
+          callback();
+        }
         self.$control_input[0].value = "";
       },
       onItemAdd: function(value, item) {
@@ -40,7 +46,9 @@ Template.chartEditTags.rendered = function() {
           }
         });
       }
-    })[0].reactiveSelectize;
+    });
+
+  tagsSelect.attach($('#tags-select'));
 
   Tracker.autorun(function(comp) {
     var routeName = Router.current().route.getName();

--- a/meteor/server/publications.js
+++ b/meteor/server/publications.js
@@ -27,6 +27,7 @@ Meteor.publish("tags", function () {
     "tagName": true,
     "tagged": true
   };
+  delete parameters.options.limit;
   var data = Tags.find(parameters.find, parameters.options);
   if (data) { return data; }
   return this.ready();


### PR DESCRIPTION
Fixes two issues:
1. The list of available tags to a chart was capped at 24. Oops!
2. If you tried to add a tag that was already added to your chart, the tagging interface blew up. No more.