### PR TITLE
Allows tags to wrap when a user adds a lot of tags to a chart

### DIFF
--- a/meteor/client/stylesheets/partials/_chart-show.scss
+++ b/meteor/client/stylesheets/partials/_chart-show.scss
@@ -4,6 +4,8 @@
   ul {
     li {
       padding-bottom: 0.3em;
+      display: inline-block;
+      margin-bottom: 10px;
     }
     span {
       @include interface-font-bold;


### PR DESCRIPTION
**On the preview chart page:** 
- If a chart contains a large amount of tags, typically six or more, the tags associated with the chart now wrap and prevents the user from needing to scroll horizontally.