### PR TITLE
Adds cache-busting tokens to embed code

### DIFF
--- a/meteor/client/templates/chart-edit/chart-edit-embed.html
+++ b/meteor/client/templates/chart-edit/chart-edit-embed.html
@@ -13,8 +13,8 @@
         b.classList.add('{{ pfx }}charttool-init');
         var c = document.createElement('link');
         var j = document.createElement('script');
-        c.href = '{{ embedCSS }}'; c.rel = 'stylesheet';
-        j.src = '{{ embedJS }}'; j.async = true; j.defer = true;
+        c.href = '{{ embedCSS }}?token={{ app_build }}'; c.rel = 'stylesheet';
+        j.src = '{{ embedJS }}?token={{ app_build }}'; j.async = true; j.defer = true;
         document.getElementsByTagName('head')[0].appendChild(c);
         document.getElementsByTagName('head')[0].appendChild(j);
       }

--- a/meteor/client/templates/chart-edit/chart-edit-embed.js
+++ b/meteor/client/templates/chart-edit/chart-edit-embed.js
@@ -18,6 +18,9 @@ Template.chartEditEmbed.helpers({
   embedJS: function() {
     if (app_settings) { return app_settings.embedJS; }
   },
+  app_build: function() {
+    if (app_build) { return app_build; }
+  },
   embedJSON: function() {
     if (!isEmpty(this)) {
       return JSON.stringify(embed(this), null, 2);

--- a/meteor/client/templates/chart-edit/chart-edit-embed.js
+++ b/meteor/client/templates/chart-edit/chart-edit-embed.js
@@ -19,7 +19,7 @@ Template.chartEditEmbed.helpers({
     if (app_settings) { return app_settings.embedJS; }
   },
   app_build: function() {
-    if (app_build) { return app_build; }
+    if (app_build && app_version) { return app_version + '-' + app_build; }
   },
   embedJSON: function() {
     if (!isEmpty(this)) {


### PR DESCRIPTION
This allows for situations where you deploy a new version without incrementing the version number. Addresses https://github.com/globeandmail/chart-tool/issues/129.