### PR TITLE
Tip data sorting and fixes broken stacked time series tips

### DIFF
--- a/meteor/lib/chart-tool/scripts/chart-tool.js
+++ b/meteor/lib/chart-tool/scripts/chart-tool.js
@@ -9646,7 +9646,11 @@ function getTipData(obj, cursor) {
   xVal = scale.invert(cursorVal);
 
   if (obj.options.stacked) {
-    var data = obj.data.stackedData;
+    var data = obj.data.stackedData.map(function (item) {
+      return item.sort(function (a, b) {
+        return a.data[obj.data.keys[0]] - b.data[obj.data.keys[0]];
+      });
+    });
     var i$1 = bisectData(data, xVal, obj.options.stacked, obj.data.keys[0]);
 
     var arr = [];
@@ -9658,7 +9662,7 @@ function getTipData(obj, cursor) {
       } else {
         var d0 = data[k][i$1[k] - 1],
           d1 = data[k][i$1[k]];
-        refIndex = xVal - d0.x > d1.x - xVal ? i$1[k] : (i$1[k] - 1);
+        refIndex = xVal - d0.data[obj.data.keys[0]] > d1.data[obj.data.keys[0]] - xVal ? i$1[k] : (i$1[k] - 1);
         arr.push(data[k][refIndex]);
       }
     }
@@ -9666,7 +9670,7 @@ function getTipData(obj, cursor) {
     tipData = arr;
 
   } else {
-    var data$1 = obj.data.data,
+    var data$1 = obj.data.data.sort(function (a, b) { return a.key - b.key; }),
       i$2 = bisectData(data$1, xVal),
       d0$1 = data$1[i$2 - 1],
       d1$1 = data$1[i$2];

--- a/src/js/charts/components/tips.js
+++ b/src/js/charts/components/tips.js
@@ -69,7 +69,11 @@ export function getTipData(obj, cursor) {
   xVal = scale.invert(cursorVal);
 
   if (obj.options.stacked) {
-    const data = obj.data.stackedData;
+    const data = obj.data.stackedData.map(item => {
+      return item.sort((a, b) => {
+        return a.data[obj.data.keys[0]] - b.data[obj.data.keys[0]];
+      });
+    });
     const i = bisectData(data, xVal, obj.options.stacked, obj.data.keys[0]);
 
     const arr = [];
@@ -81,7 +85,7 @@ export function getTipData(obj, cursor) {
       } else {
         const d0 = data[k][i[k] - 1],
           d1 = data[k][i[k]];
-        refIndex = xVal - d0.x > d1.x - xVal ? i[k] : (i[k] - 1);
+        refIndex = xVal - d0.data[obj.data.keys[0]] > d1.data[obj.data.keys[0]] - xVal ? i[k] : (i[k] - 1);
         arr.push(data[k][refIndex]);
       }
     }
@@ -89,7 +93,7 @@ export function getTipData(obj, cursor) {
     tipData = arr;
 
   } else {
-    const data = obj.data.data,
+    const data = obj.data.data.sort((a, b) => a.key - b.key),
       i = bisectData(data, xVal),
       d0 = data[i - 1],
       d1 = data[i];


### PR DESCRIPTION
Addresses https://github.com/globeandmail/chart-tool/issues/140, and fixes a bug where stacked time-series data was returning `undefined` due to changes to stacking behaviour in D3 v4.