### PR TITLE
fixes up range dates

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ Otherwise, these are some other tutorials you might want to check out:
 
 ## Version
 
-1.4.0
+1.4.1
 
 
 ## License

--- a/meteor/imports/modules/chart-tool.js
+++ b/meteor/imports/modules/chart-tool.js
@@ -1,4 +1,4 @@
-/* Chart Tool v1.4.0-0 | https://github.com/globeandmail/chart-tool | MIT */
+/* Chart Tool v1.4.1-0 | https://github.com/globeandmail/chart-tool | MIT */
 (function (global, factory) {
 	typeof exports === 'object' && typeof module !== 'undefined' ? module.exports = factory() :
 	typeof define === 'function' && define.amd ? define(factory) :
@@ -2492,8 +2492,6 @@
 	var saturday = weekday(6);
 
 	var sundays = sunday.range;
-	var mondays = monday.range;
-	var thursdays = thursday.range;
 
 	var month = newInterval(function(date) {
 	  date.setDate(1);
@@ -2583,8 +2581,6 @@
 	var utcSaturday = utcWeekday(6);
 
 	var utcSundays = utcSunday.range;
-	var utcMondays = utcMonday.range;
-	var utcThursdays = utcThursday.range;
 
 	var utcMonth = newInterval(function(date) {
 	  date.setUTCDate(1);
@@ -3544,7 +3540,7 @@
 		thumbnailWidth: 460
 	};
 
-	var version = "1.4.0";
+	var version = "1.4.1";
 	var buildVer = "0";
 
 	var chartSettings = {
@@ -13536,8 +13532,11 @@
 	    start = Number(rangeObj.start);
 	    if ('end' in rangeObj) { end = Number(rangeObj.end); }
 	  } else {
-	    start = new Date(rangeObj.start);
-	    if ('end' in rangeObj) { end = new Date(rangeObj.end); }
+	    var dateFormat = timeParse(obj.data.inputDateFormat);
+	    start = dateFormat(rangeObj.start);
+	    if ('end' in rangeObj) { end = dateFormat(rangeObj.end); }
+	    // start = new Date(rangeObj.start);
+	    // if ('end' in rangeObj) end = new Date(rangeObj.end);
 	  }
 
 	  var attrs = {
@@ -13573,7 +13572,7 @@
 	  } else {
 	    type = 'line';
 
-	    // cancels out offsetting for leftmost column)
+	    // cancels out offsetting for leftmost column
 	    var sameStarts = new Date(start).toString() === scale.domain()[0].toString();
 	    if (isColumnAndX && sameStarts) { offset = 0; }
 	    attrs.x1 = rangeObj.axis === 'x' ? scale(start) + offset : 0;
@@ -13629,7 +13628,8 @@
 
 	  var scale = obj.rendered.plot[((obj.annotationHandlers.rangeAxis) + "ScaleObj")].scale,
 	    scaleType = obj.rendered.plot[((obj.annotationHandlers.rangeAxis) + "ScaleObj")].obj.type,
-	    isTime = scaleType === 'time' || scaleType === 'ordinal-time';
+	    isTime = scaleType === 'time' || scaleType === 'ordinal-time',
+	    dateFormat = isTime ? timeParse(obj.data.inputDateFormat) : function (x) { return x; };
 
 	  if (hasRangePassedFromInterface) {
 	    var move;
@@ -13641,13 +13641,13 @@
 	    var offset = isColumnAndX ? obj.rendered.plot.singleColumn : 0;
 
 	    if (obj.annotationHandlers.rangeType === 'line') {
-	      var sameStarts = new Date(start).toString() === scale.domain()[0].toString();
+	      var sameStarts = dateFormat(start).toString() === scale.domain()[0].toString();
 	      if (isColumnAndX && sameStarts) { offset = 0; }
-	      move = getBrushFromCenter(obj, scale(isTime ? new Date(start) : Number(start)) + offset);
+	      move = getBrushFromCenter(obj, scale(isTime ? dateFormat(start) : Number(start)) + offset);
 	    } else {
 	      move = [
-	        scale(isTime ? new Date(start) : Number(start)),
-	        scale(isTime ? new Date(end) : Number(end)) + offset
+	        scale(isTime ? dateFormat(start) : Number(start)),
+	        scale(isTime ? dateFormat(end) : Number(end)) + offset
 	      ];
 
 	    }
@@ -13767,7 +13767,10 @@
 	  }
 
 	  if (scaleObj.obj.type === 'time' || scaleObj.obj.type === 'ordinal-time') {
-	    fn = function (d) { return getTipData(obj, { x: d }).key; };
+	    fn = function (d) {
+	      var data = getTipData(obj, { x: d });
+	      return data.originalKey || data.key;
+	    };
 	  }
 
 	  return fn;

--- a/meteor/imports/modules/settings.js
+++ b/meteor/imports/modules/settings.js
@@ -155,7 +155,7 @@ var config = {
 };
 
 var name = "chart-tool";
-var version = "1.4.0";
+var version = "1.4.1";
 var buildVer = "0";
 
 var app_version = version;

--- a/meteor/imports/ui/components/ChartAnnotations.js
+++ b/meteor/imports/ui/components/ChartAnnotations.js
@@ -3,7 +3,6 @@ import { TwitterPicker as ColorPicker } from 'react-color';
 import { updateAndSave, dataParse, isNumber } from '../../modules/utils';
 import { app_settings } from '../../modules/settings';
 import { parse } from '../../modules/chart-tool';
-import { timeFormat } from 'd3-time-format';
 import Swal from 'sweetalert2';
 import Slider from 'rc-slider';
 
@@ -131,8 +130,7 @@ export default class ChartAnnotations extends Component {
     const axis = this.props.chart[`${this.props.currentAnnotation.rangeAxis}_axis`];
 
     if (axis.scale === 'time' || axis.scale === 'ordinal-time') {
-      const formatTime = timeFormat(this.props.chart.date_format);
-      return formatTime(new Date(data));
+      return data;
     } else {
 
       // if it's direct input, let it be whatever the user wants
@@ -181,10 +179,12 @@ export default class ChartAnnotations extends Component {
       <div className={`range-row-item ${rangeType === 'line' && type === 'rangeEnd' ? 'muted' : ''}`}>
         <label
           className={`range-value ${scaleType === 'linear' ? 'editable' : ''}`}
-          htmlFor={type}>{labelText}</label>
+        >{labelText}</label>
         <input
           id={type}
           type={scaleType === 'linear' ? 'number' : 'text'}
+          tabIndex={scaleType === 'linear' ? '' : '-1'}
+          readOnly={scaleType === 'linear' ? false : true}
           className={`range-value ${scaleType === 'linear' ? 'editable' : ''}`}
           value={this.formatRangeValue(type)}
           onChange={this.setRangeValue}
@@ -588,9 +588,8 @@ export default class ChartAnnotations extends Component {
                       const axis = this.props.chart[`${d.axis}_axis`];
                       const data = {};
                       if (axis.scale === 'time' || axis.scale === 'ordinal-time') {
-                        const formatTime = timeFormat(this.props.chart.date_format);
-                        data.start = formatTime(new Date(d.start));
-                        data.end = formatTime(new Date(d.end));
+                        data.start = d.start;
+                        data.end = d.end;
                       } else {
                         const rangeFormatting = {
                           auto: 100,

--- a/src/js/charts/components/annotation.js
+++ b/src/js/charts/components/annotation.js
@@ -6,6 +6,7 @@ import { isNumeric, roundToPrecision } from '../../helpers/helpers';
 import { cursorPos, getTipData } from './tips';
 import { interpolateObject } from 'd3-interpolate';
 import { line, curveBasis } from 'd3-shape';
+import { timeParse } from 'd3-time-format';
 
 export default function annotation(node, obj) {
 
@@ -104,8 +105,11 @@ export function drawRangeAnnotation(obj, rangeObj, i, annoNode) {
     start = Number(rangeObj.start);
     if ('end' in rangeObj) end = Number(rangeObj.end);
   } else {
-    start = new Date(rangeObj.start);
-    if ('end' in rangeObj) end = new Date(rangeObj.end);
+    const dateFormat = timeParse(obj.data.inputDateFormat);
+    start = dateFormat(rangeObj.start);
+    if ('end' in rangeObj) end = dateFormat(rangeObj.end);
+    // start = new Date(rangeObj.start);
+    // if ('end' in rangeObj) end = new Date(rangeObj.end);
   }
 
   const attrs = {
@@ -141,7 +145,7 @@ export function drawRangeAnnotation(obj, rangeObj, i, annoNode) {
   } else {
     type = 'line';
 
-    // cancels out offsetting for leftmost column)
+    // cancels out offsetting for leftmost column
     const sameStarts = new Date(start).toString() === scale.domain()[0].toString();
     if (isColumnAndX && sameStarts) offset = 0;
     attrs.x1 = rangeObj.axis === 'x' ? scale(start) + offset : 0;
@@ -197,7 +201,8 @@ export function editableRange(annoEditable, obj) {
 
   const scale = obj.rendered.plot[`${obj.annotationHandlers.rangeAxis}ScaleObj`].scale,
     scaleType = obj.rendered.plot[`${obj.annotationHandlers.rangeAxis}ScaleObj`].obj.type,
-    isTime = scaleType === 'time' || scaleType === 'ordinal-time';
+    isTime = scaleType === 'time' || scaleType === 'ordinal-time',
+    dateFormat = isTime ? timeParse(obj.data.inputDateFormat) : x => x;
 
   if (hasRangePassedFromInterface) {
     let move;
@@ -209,13 +214,13 @@ export function editableRange(annoEditable, obj) {
     let offset = isColumnAndX ? obj.rendered.plot.singleColumn : 0;
 
     if (obj.annotationHandlers.rangeType === 'line') {
-      const sameStarts = new Date(start).toString() === scale.domain()[0].toString();
+      const sameStarts = dateFormat(start).toString() === scale.domain()[0].toString();
       if (isColumnAndX && sameStarts) offset = 0;
-      move = getBrushFromCenter(obj, scale(isTime ? new Date(start) : Number(start)) + offset);
+      move = getBrushFromCenter(obj, scale(isTime ? dateFormat(start) : Number(start)) + offset);
     } else {
       move = [
-        scale(isTime ? new Date(start) : Number(start)),
-        scale(isTime ? new Date(end) : Number(end)) + offset
+        scale(isTime ? dateFormat(start) : Number(start)),
+        scale(isTime ? dateFormat(end) : Number(end)) + offset
       ];
 
     }
@@ -335,7 +340,10 @@ export function scaleAccessor(axis, obj) {
   }
 
   if (scaleObj.obj.type === 'time' || scaleObj.obj.type === 'ordinal-time') {
-    fn = d => getTipData(obj, { x: d }).key;
+    fn = d => {
+      const data = getTipData(obj, { x: d });
+      return data.originalKey || data.key;
+    };
   }
 
   return fn;


### PR DESCRIPTION
Fixes annotation range dates to use `d.originalKey`-type dates instead of `d.key`-type dates. Also adds a couple of fixes to ensure fields are `readonly` when editing a time scale axis.